### PR TITLE
Nbt serialization configuration

### DIFF
--- a/fabrikmc-nbt/src/main/kotlin/net/axay/fabrik/nbt/NbtSerialization.kt
+++ b/fabrikmc-nbt/src/main/kotlin/net/axay/fabrik/nbt/NbtSerialization.kt
@@ -43,3 +43,5 @@ inline fun <reified T> Nbt.encodeToNbtElement(value: T) =
 
 inline fun <reified T> Nbt.decodeFromNbtElement(element: NbtElement) =
     decodeFromNbtElement(serializer<T>(), element)
+
+class UnknownKeyException(val key: String) : SerializationException("Encountered unknown key '$key'")

--- a/fabrikmc-nbt/src/main/kotlin/net/axay/fabrik/nbt/NbtSerialization.kt
+++ b/fabrikmc-nbt/src/main/kotlin/net/axay/fabrik/nbt/NbtSerialization.kt
@@ -12,17 +12,17 @@ sealed class Nbt(val config: NbtConfig, val serializersModule: SerializersModule
     companion object Default : Nbt(NbtConfig(), EmptySerializersModule)
 
     fun <T> encodeToNbtElement(serializer: SerializationStrategy<T>, value: T): NbtElement =
-        NbtRootEncoder(serializersModule).apply { encodeSerializableValue(serializer, value) }.element
+        NbtRootEncoder(this).apply { encodeSerializableValue(serializer, value) }.element
             ?: throw SerializationException("Serializer did not encode any element")
 
     fun <T> decodeFromNbtElement(deserializer: DeserializationStrategy<T>, element: NbtElement): T =
-        NbtRootDecoder(serializersModule, element).decodeSerializableValue(deserializer)
+        NbtRootDecoder(this, element).decodeSerializableValue(deserializer)
 }
 
 private class NbtImpl(config: NbtConfig, serializersModule: SerializersModule) : Nbt(config, serializersModule)
 
 data class NbtConfig(
-    val shouldEncodeDefaults: Boolean = false,
+    val encodeDefaults: Boolean = false,
     val ignoreUnknownKeys: Boolean = false
 )
 
@@ -30,7 +30,7 @@ inline fun Nbt(from: Nbt = Nbt.Default, build: NbtBuilder.() -> Unit): Nbt =
     NbtBuilder(from).apply(build).build()
 
 class NbtBuilder(from: Nbt) {
-    var shouldEncodeDefaults = from.config.shouldEncodeDefaults
+    var encodeDefaults = from.config.encodeDefaults
     var ignoreUnknownKeys = from.config.ignoreUnknownKeys
 
     var serializersModule = from.serializersModule

--- a/fabrikmc-nbt/src/main/kotlin/net/axay/fabrik/nbt/NbtSerialization.kt
+++ b/fabrikmc-nbt/src/main/kotlin/net/axay/fabrik/nbt/NbtSerialization.kt
@@ -35,7 +35,7 @@ class NbtBuilder(from: Nbt) {
 
     var serializersModule = from.serializersModule
 
-    fun build(): Nbt = NbtImpl(NbtConfig(), serializersModule)
+    fun build(): Nbt = NbtImpl(NbtConfig(encodeDefaults, ignoreUnknownKeys), serializersModule)
 }
 
 inline fun <reified T> Nbt.encodeToNbtElement(value: T) =

--- a/fabrikmc-nbt/src/test/kotlin/net/axay/fabrik/nbt/NbtDecodingTest.kt
+++ b/fabrikmc-nbt/src/test/kotlin/net/axay/fabrik/nbt/NbtDecodingTest.kt
@@ -1,5 +1,7 @@
 package net.axay.fabrik.nbt
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -98,5 +100,18 @@ class NbtDecodingTest : StringSpec({
             }
         }
         Nbt.decodeFromNbtElement<SealedBase>(compound) shouldBe value
+    }
+
+    "decoding should honor ignoreUnknownKeys setting" {
+        val withUnknown = nbtCompound {
+            put("one", 1)
+            put("unknown", 4.5)
+        }
+        shouldThrow<UnknownKeyException> {
+            Nbt.decodeFromNbtElement<TestClassWithDefault>(withUnknown)
+        }.key shouldBe "unknown"
+        Nbt {
+            ignoreUnknownKeys = true
+        }.decodeFromNbtElement<TestClassWithDefault>(withUnknown) shouldBe TestClassWithDefault(1)
     }
 })

--- a/fabrikmc-nbt/src/test/kotlin/net/axay/fabrik/nbt/NbtEncodingTest.kt
+++ b/fabrikmc-nbt/src/test/kotlin/net/axay/fabrik/nbt/NbtEncodingTest.kt
@@ -122,4 +122,19 @@ class NbtEncodingTest : StringSpec({
             getDouble("childProp") shouldBe value.childProp
         }
     }
+
+    "defaults should only be encoded when the config value is set" {
+        val value = TestClassWithDefault()
+        with(Nbt.encodeToNbtElement(value)) {
+            shouldBeInstanceOf<NbtCompound>()
+            isEmpty shouldBe true
+        }
+
+        with(Nbt { encodeDefaults = true }.encodeToNbtElement(value)) {
+            shouldBeInstanceOf<NbtCompound>()
+            size shouldBe 2
+            getInt("one") shouldBe value.one
+            getBoolean("tru") shouldBe value.tru
+        }
+    }
 })

--- a/fabrikmc-nbt/src/test/kotlin/net/axay/fabrik/nbt/TestClasses.kt
+++ b/fabrikmc-nbt/src/test/kotlin/net/axay/fabrik/nbt/TestClasses.kt
@@ -17,6 +17,9 @@ data class TestClass(
 @Serializable
 data class InnerTestClass(val test: Boolean)
 
+@Serializable
+data class TestClassWithDefault(val one: Int = 1, val tru: Boolean = true)
+
 enum class TestEnum {
     VARIANT_1, VARIANT_2, LastVariant,
 }


### PR DESCRIPTION
Allows users to ignore unknown compound keys and chose whether to encode default values.